### PR TITLE
Allow string or number as width/height

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,13 +1,17 @@
 import React, {PropTypes} from 'react';
 import {Code39} from 'tualo-code39';
 
+const stringOrNumber = PropTypes.oneOfType([
+    PropTypes.number,
+    PropTypes.string
+  ])
 
 export default class Code39Svg extends React.Component {
 
   static propTypes = {
     children: PropTypes.string.isRequired,
-    width: PropTypes.number.isRequired,
-    height: PropTypes.number.isRequired,
+    width: stringOrNumber.isRequired,
+    height: stringOrNumber.isRequired,
   }
 
   render() {


### PR DESCRIPTION
Strings (for % width/height) are useful here.

I only quick-edited this via GitHub's web editor. I think it's a small enough change that it doesn't warrant a lot of checking and testing, but if you'd like I can clone it down and write some kind of test for it. `</lazy>`
